### PR TITLE
ci: update branch environment mapping to support develop branch

### DIFF
--- a/.github/workflows/vtd-trigger.yml
+++ b/.github/workflows/vtd-trigger.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 60
     runs-on: ubuntu-latest
     outputs:
-      env: ${{ steps.target-branch.outputs.value == 'main' && 'dev' || 'stg' }}
+      env: ${{ (steps.target-branch.outputs.value == 'main' || steps.target-branch.outputs.value == 'develop') && 'dev' || 'stg' }}
     strategy:
       matrix:
         include: ${{ fromJson(vars.STRATEGY_MATRIX_SERVICES) }}
@@ -188,7 +188,7 @@ jobs:
           TRIGGERING_REF=${{ env.REF_NAME }}
           TRIGGERING_SERVICE_NAME=${{ matrix.service }}
           TRIGGERING_REPOSITORY=${{ secrets.VTD_REPOSITORY_TARGET }}${{ matrix.service }}
-          TRIGGERING_ENV=${{ steps.target-branch.outputs.value == 'main' && 'dev' || 'stg' }}
+          TRIGGERING_ENV=${{ (steps.target-branch.outputs.value == 'main' || steps.target-branch.outputs.value == 'develop') && 'dev' || 'stg' }}
           TRIGHERING_VERSION=$(git rev-parse HEAD)
           TRIGHERING_HASH=$(git rev-parse HEAD)
           curl -L \


### PR DESCRIPTION
Context:
Dự án đang đổi nhánh phát triển chính sang develop (thay thế cho main). Do file vtd-trigger.yml hiện tại check cứng tên nhánh là 'main' mới deploy lên 'dev' (còn lại mặc định lên 'stg'), nên bắt buộc phải sửa file workflow này thay vì chỉ đổi tên nhánh thành 'dev'.

Giải pháp:
Cập nhật logic trong vtd-trigger.yml để cả 2 nhánh 'main' và 'develop' đều được deploy chính xác lên môi trường 'dev'.

Chi tiết thay đổi:
Sửa điều kiện tại dòng 28 (outputs.env) và dòng 191 (TRIGGERING_ENV) từ check 'main' thành check:
(steps.target-branch.outputs.value == 'main' || steps.target-branch.outputs.value == 'develop')